### PR TITLE
Fix a freezing issue when using Mesa on Linux with the Forge splash

### DIFF
--- a/src/main/java/com/gildedgames/util/menu/client/MenuClientEvents.java
+++ b/src/main/java/com/gildedgames/util/menu/client/MenuClientEvents.java
@@ -39,6 +39,8 @@ public class MenuClientEvents
 	private Minecraft mc = Minecraft.getMinecraft();
 
 	private File configSaveLocation;
+	
+	private boolean firstTick = true;
 
 	public static class MenuConfig implements NBT
 	{
@@ -90,7 +92,10 @@ public class MenuClientEvents
 
 		menu.onOpen();
 
-		Mouse.setCursorPosition(mouseX, mouseY);
+		if (!firstTick)
+		{
+			Mouse.setCursorPosition(mouseX, mouseY);
+		}
 
 		if (!shouldSaveToConfig)
 		{
@@ -163,11 +168,16 @@ public class MenuClientEvents
 		}
 	}
 
+	
 	@SubscribeEvent
 	public void tickStart(TickEvent.ClientTickEvent event)
 	{
 		if (event.phase == TickEvent.Phase.START)
 		{
+			if (firstTick)
+			{
+				firstTick = false;
+			}
 			IMenu menu = MenuCore.locate().getCurrentMenu();
 
 			if (menu != null)


### PR DESCRIPTION
Fixes gildedgames/aether-issues#570

Setting the cursor position within the first tick of the game starting, on Linux, causes a crash due to X dequeuing an unknown request.  This is likely due to a race condition caused by the (threaded) Forge loading screen relinquishing control over the input system.

This PR adds a simple boolean to MenuClientEvents that starts as true, and is set to false when the first tick occurs.  The cursor position will only be set on menu show if this boolean is false.
